### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "laravel/framework": ">=5.2.0"
+        "laravel/framework": "5.2.* || 5.3.* || 5.4.* || 5.5.*"
     },
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.