### PR TITLE
Fix config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $settings = Setting::all();
 ```php
 setting('foo', 'default');
 setting('nested.element');
-setting(['foo', 'bar']);
+setting(['foo' => 'bar']);
 setting()->forget('foo');
 $settings = setting()->all();
 ```

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -37,7 +37,7 @@ class Provider extends ServiceProvider
         // Override config
         if (config('setting.override')) {
             foreach (config('setting.override') as $config_key => $setting_key) {
-                config([$config_key, setting($setting_key)]);
+                config([$config_key => setting($setting_key)]);
             }
         }
 


### PR DESCRIPTION
As documented in https://laravel.com/docs/5.5/helpers, if parameter is an array, than it should formatted in [$key => $value] pair, not [$key, $value]