### PR TITLE
Fixes issue #6

### DIFF
--- a/src/Middleware/AutoSaveSetting.php
+++ b/src/Middleware/AutoSaveSetting.php
@@ -2,19 +2,17 @@
 
 namespace Akaunting\Setting\Middleware;
 
-use Akaunting\Setting\Contracts\Driver;
 use Closure;
 
 class AutoSaveSetting
 {
 	/**
 	 * Create a new save settings middleware
-	 * 
-	 * @param Driver $settings
+	 *
 	 */
-	public function __construct(Driver $setting)
+	public function __construct()
 	{
-		$this->setting = $setting;
+		$this->setting = app('setting');
 	}
 
 	/**


### PR DESCRIPTION
Target [Akaunting\Setting\Contracts\Driver] is not instantiable error
is thrown when auto_save setting enabled. This commit fixes that issue