### PR TITLE
Remove non-associative sample when override config

### DIFF
--- a/src/Config/setting.php
+++ b/src/Config/setting.php
@@ -60,7 +60,6 @@ return [
     | If defined, settings package will override these config values.
     |
     | Sample:
-    |   "app.fallback_locale",
     |   "app.locale" => "settings.locale",
     |
     */


### PR DESCRIPTION
Non-associative values for `override` will not work if it contains more than 1 item, e.g.:
```php
  'override' => [
      "app.locale",  // key = 0
      "app.name" , // key = 1
    ],
```

For second item, we will have new config value `1 => setting("app.name")`, not `"app.name" => setting("app.name")`