### PR TITLE
Fixed config override for not-db drivers

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -40,8 +40,12 @@ class Provider extends ServiceProvider
         foreach (Arr::dot($override) as $configKey => $settingKey) {
             $configKey = $configKey ?: $settingKey;
 
-            if (! is_null($value = setting($settingKey))) {
-                config([$configKey => $value]);
+            try {
+                if (! is_null($value = setting($settingKey))) {
+                    config([$configKey => $value]);
+                }
+            } catch (\Exception $e) {	
+                continue;	
             }
         }
 


### PR DESCRIPTION
If no migration is run, exception is thrown.