### PR TITLE
pull override functionality into own method; fix null config_key check

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -34,20 +34,8 @@ class Provider extends ServiceProvider
             $kernel = $this->app['Illuminate\Contracts\Http\Kernel'];
             $kernel->pushMiddleware(AutoSaveSetting::class);
         }
-        
-        $override = config('setting.override', []);
 
-        foreach (Arr::dot($override) as $config_key => $setting_key) {
-            $config_key = $config_key ?: $setting_key;
-
-            try {
-                if (! is_null($value = setting($setting_key))) {
-                    config([$config_key => $value]);
-                }
-            } catch (\Exception $e) {
-                continue;
-            }
-        }
+        $this->override();
 
         // Register blade directive
         Blade::directive('setting', function ($expression) {
@@ -63,5 +51,22 @@ class Provider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/Config/setting.php', 'setting');
+    }
+
+    private function override()
+    {
+        $override = config('setting.override', []);
+
+        foreach (Arr::dot($override) as $config_key => $setting_key) {
+            $config_key = is_string($config_key) ? $config_key : $setting_key;
+
+            try {
+                if (! is_null($value = setting($setting_key))) {
+                    config([$config_key => $value]);
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
     }
 }


### PR DESCRIPTION
`$config_key = $config_key ?: $setting_key;` will use the $config_key even if it's not defined (_unless_ it's the first item in the array) That's because all arrays are keyed:

[Example #4 Indexed arrays without key](https://www.php.net/manual/en/language.types.array.php#example-60)
[Example #5 Keys not on all elements](https://www.php.net/manual/en/language.types.array.php#example-61)

Consider this example:

```
$array  = [
    'key', 
    'another_key', 
    'config_key' => 'setting_key'
];
```
Is actually this:
```
[
  0 => "key"
  // works as expected because $config_key evaluates as false
  1 => "another_key"
  // whereas this is true, so, $config_key === 1
  "config_key" => "setting_key"
]
```

So to resolve, I've just checked to see if the key is a string instead of null.