### PR TITLE
Encryption support for database driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This package allows you to save settings in a more persistent way. You can use t
 * Helper function
 * Blade directive
 * Override config values
+* Encryption
 * Custom file, table and columns
 * Auto save
 * Extra columns
@@ -95,7 +96,7 @@ If you enable the `auto_save` option in the config file, settings will be saved 
 
 You can get the settings directly in your blade templates using the helper method or the blade directive like `@setting('foo')`
 
-### Override Config Values 
+### Override Config Values
 
 You can easily override default config values by adding them to the `override` option in `config/setting.php`, thereby eliminating the need to modify the default config files and also allowing you to change said values during production. Ex :
 ```php
@@ -107,6 +108,15 @@ You can easily override default config values by adding them to the `override` o
 ],
 ```
 The values on the left corresponds to the respective config value (Ex: config('app.name')) and the value on the right is the name of the `key` in your settings table/json file.
+
+### Encryption
+
+If you like to encrypt the values for a give key, you can pass the key to the `encrypted_keys` option in `config/setting.php` and the rest is automatically handled by using Laravel's built-in encryption facilities. Ex:
+```php
+'encrypted_keys' => [
+        "payment.key" => "payment_key",
+],
+```
 
 ### JSON Storage
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The values on the left corresponds to the respective config value (Ex: config('a
 If you like to encrypt the values for a give key, you can pass the key to the `encrypted_keys` option in `config/setting.php` and the rest is automatically handled by using Laravel's built-in encryption facilities. Ex:
 ```php
 'encrypted_keys' => [
-        "payment.key" => "payment_key",
+        "payment.key",
 ],
 ```
 

--- a/src/Config/setting.php
+++ b/src/Config/setting.php
@@ -98,4 +98,19 @@ return [
     'required_extra_columns' => [
 
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption
+    |--------------------------------------------------------------------------
+    |
+    | Define the keys which should be crypt automatically.
+    |
+    | Sample:
+    |   "payment.key"
+    |
+    */
+   'encrypted_keys' => [
+
+   ],
 ];

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -245,7 +245,8 @@ class Database extends Driver
      *
      * @return string
      */
-    protected function prepareValue(string $key, $value) {
+    protected function prepareValue(string $key, $value)
+    {
 
         // Check if key should be encrypted
         if (in_array($key, $this->encryptedKeys)) {
@@ -265,7 +266,8 @@ class Database extends Driver
      *
      * @return string
      */
-    protected function unpackValue(string $key, $value) {
+    protected function unpackValue(string $key, $value)
+    {
 
         // Check if key should be encrypted
         if (in_array($key, $this->encryptedKeys)) {

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -183,7 +183,7 @@ class Database extends Driver
         }
 
         foreach ($update_data as $key => $value) {
-            $value = $this->prepareValue($value);
+            $value = $this->prepareValue($key, $value);
 
             $this->newQuery()
                 ->where($this->key, '=', $key)
@@ -217,7 +217,7 @@ class Database extends Driver
 
         if ($this->getExtraColumns()) {
             foreach ($data as $key => $value) {
-                $value = $this->prepareValue($value);
+                $value = $this->prepareValue($key, $value);
 
                 $db_data[] = array_merge(
                     $this->getExtraColumns(),
@@ -226,7 +226,7 @@ class Database extends Driver
             }
         } else {
             foreach ($data as $key => $value) {
-                $value = $this->prepareValue($value);
+                $value = $this->prepareValue($key, $value);
 
                 $db_data[] = [$this->key => $key, $this->value => $value];
             }

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -70,7 +70,7 @@ class Database extends Driver
         $this->table = $table ?: 'settings';
         $this->key = $key ?: 'key';
         $this->value = $value ?: 'value';
-        $this->encryptedKeys = $encryptedKeys;
+        $this->encryptedKeys = $encryptedKeys ?: [];
     }
 
     /**

--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -4,9 +4,10 @@ namespace Akaunting\Setting\Drivers;
 
 use Akaunting\Setting\Contracts\Driver;
 use Akaunting\Setting\Support\Arr;
-use Illuminate\Support\Arr as LaravelArr;
 use Closure;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Arr as LaravelArr;
+use Illuminate\Support\Facades\Crypt;
 
 class Database extends Driver
 {
@@ -39,6 +40,13 @@ class Database extends Driver
     protected $value;
 
     /**
+     * Keys which should be encrypt automatically.
+     *
+     * @var string
+     */
+    protected $encryptedKeys;
+
+    /**
      * Any query constraints that should be applied.
      *
      * @var Closure|null
@@ -56,12 +64,13 @@ class Database extends Driver
      * @param \Illuminate\Database\Connection $connection
      * @param string $table
      */
-    public function __construct(Connection $connection, $table = null, $key = null, $value = null)
+    public function __construct(Connection $connection, $table = null, $key = null, $value = null, $encryptedKeys = [])
     {
         $this->connection = $connection;
         $this->table = $table ?: 'settings';
         $this->key = $key ?: 'key';
         $this->value = $value ?: 'value';
+        $this->encryptedKeys = $encryptedKeys;
     }
 
     /**
@@ -174,6 +183,8 @@ class Database extends Driver
         }
 
         foreach ($update_data as $key => $value) {
+            $value = $this->prepareValue($value);
+
             $this->newQuery()
                 ->where($this->key, '=', $key)
                 ->update([$this->value => $value]);
@@ -206,6 +217,8 @@ class Database extends Driver
 
         if ($this->getExtraColumns()) {
             foreach ($data as $key => $value) {
+                $value = $this->prepareValue($value);
+
                 $db_data[] = array_merge(
                     $this->getExtraColumns(),
                     [$this->key => $key, $this->value => $value]
@@ -213,11 +226,54 @@ class Database extends Driver
             }
         } else {
             foreach ($data as $key => $value) {
+                $value = $this->prepareValue($value);
+
                 $db_data[] = [$this->key => $key, $this->value => $value];
             }
         }
 
         return $db_data;
+    }
+
+    /**
+     * Checks if the provided key should be encrypted or not.
+     * Also type casts the given value to a string so errors with booleans or integers are handeled.
+     * Otherwise it returns the original value.
+     *
+     * @param  string $key   Key to check if it's inside the encryptedValues variable.
+     * @param  mixed $value  Info: Encryption only supports strings.
+     *
+     * @return string
+     */
+    protected function prepareValue(string $key, $value) {
+
+        // Check if key should be encrypted
+        if (in_array($key, $this->encryptedKeys)) {
+            // Cast to string to avoid error when a user passes a boolean value
+            return Crypt::encryptString((string) $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Checks if the provided key should be decrypted or not.
+     * Otherwise it returns the original value.
+     *
+     * @param  string $key   Key to check if it's inside the encryptedValues variable.
+     * @param  mixed $value  Info: Encryption only supports strings.
+     *
+     * @return string
+     */
+    protected function unpackValue(string $key, $value) {
+
+        // Check if key should be encrypted
+        if (in_array($key, $this->encryptedKeys)) {
+            // Cast to string to avoid error when a user passes a boolean value
+            return Crypt::decryptString((string) $value);
+        }
+
+        return $value;
     }
 
     /**
@@ -250,6 +306,9 @@ class Database extends Driver
                 $msg = 'Expected array or object, got ' . gettype($row);
                 throw new \UnexpectedValueException($msg);
             }
+
+            // Encryption
+            $value = $this->unpackValue($key, $value);
 
             Arr::set($results, $key, $value);
         }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -58,7 +58,7 @@ class Manager extends BaseManager
         $table = config('setting.database.table');
         $key = config('setting.database.key');
         $value = config('setting.database.value');
-        $encryptedKeys = config('settings.encrypted_keys');
+        $encryptedKeys = config('setting.encrypted_keys');
 
         return new Database($connection, $table, $key, $value, $encryptedKeys);
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -58,8 +58,9 @@ class Manager extends BaseManager
         $table = config('setting.database.table');
         $key = config('setting.database.key');
         $value = config('setting.database.value');
+        $encryptedKeys = config('settings.encrypted_keys');
 
-        return new Database($connection, $table, $key, $value);
+        return new Database($connection, $table, $key, $value, $encryptedKeys);
     }
 
     public function createMemoryDriver()


### PR DESCRIPTION
Hi,

this PR implements support for encryption, based on keys defined in the config file. You can define the keys which should be automatically encrypted by using Laravel's built-in encryption.

I think this could be very helpful when you want to provide your users a form where they can update api keys for third party services. Those information should only be stored as an encrypted string.

Would like to hear your feedback about this PR and hopefully someone else would love to have this feature.