### PR TITLE
Bindings should be placed in register()

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ class MyDriver extends Akaunting\Setting\Contracts\Driver
 	// ...
 }
 
-setting()->extend('mydriver', function($app) {
+app('setting.manager')->extend('mydriver', function($app) {
 	return $app->make('MyDriver');
 });
 ```

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -21,14 +21,6 @@ class Provider extends ServiceProvider
             __DIR__ . '/Migrations/2017_08_24_000000_create_settings_table.php' => database_path('migrations/2017_08_24_000000_create_settings_table.php'),
         ], 'setting');
 
-        $this->app->singleton('setting.manager', function ($app) {
-            return new Manager($app);
-        });
-
-        $this->app->singleton('setting', function ($app) {
-            return $app['setting.manager']->driver();
-        });
-
         // Auto save setting
         if (config('setting.auto_save')) {
             $kernel = $this->app['Illuminate\Contracts\Http\Kernel'];
@@ -50,6 +42,14 @@ class Provider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->singleton('setting.manager', function ($app) {
+            return new Manager($app);
+        });
+
+        $this->app->singleton('setting', function ($app) {
+            return $app['setting.manager']->driver();
+        });
+
         $this->mergeConfigFrom(__DIR__ . '/Config/setting.php', 'setting');
     }
 


### PR DESCRIPTION
It is better to place bindings in register() method.
This way, the manager will be already in place by the time we want to extend the manager with our custom driver.

I fix the example in the README related to extending the manager with our custom driver as well.
Kindly review the changes.